### PR TITLE
11 sopac geodesyml translator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>au.gov.ga.geodesy</groupId>
     <artifactId>geodesyml-bindings</artifactId>
@@ -13,6 +14,7 @@
     </scm>
     <properties>
         <java.version>1.8</java.version>
+        <spring.version>4.1.6.RELEASE</spring.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <encoding>UTF-8</encoding>
@@ -44,6 +46,22 @@
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.moxy</artifactId>
             <version>2.5.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <profiles>

--- a/src/main/java/au/gov/ga/geodesy/bindings/AppConfig.java
+++ b/src/main/java/au/gov/ga/geodesy/bindings/AppConfig.java
@@ -1,18 +1,9 @@
 package au.gov.ga.geodesy.bindings;
  
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-
-import au.gov.ga.geodesy.interfaces.geodesyml.GeodesyMLMarshaller;
-import au.gov.ga.geodesy.interfaces.geodesyml.MarshallingException;
-import au.gov.ga.geodesy.support.marshalling.moxy.GeodesyMLMoxy;
  
 @Configuration
 @ComponentScan(basePackages = "au.gov.ga.geodesy")
 public class AppConfig {
-    @Bean
-    public GeodesyMLMarshaller getGeodesyMLMarshaller() throws MarshallingException {
-        return new GeodesyMLMoxy();
-    }
 }

--- a/src/main/java/au/gov/ga/geodesy/bindings/AppConfig.java
+++ b/src/main/java/au/gov/ga/geodesy/bindings/AppConfig.java
@@ -1,0 +1,10 @@
+package au.gov.ga.geodesy.bindings;
+ 
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+ 
+@Configuration
+@ComponentScan(basePackages = "au.gov.ga.geodesy")
+public class AppConfig {
+ 
+}

--- a/src/main/java/au/gov/ga/geodesy/bindings/AppConfig.java
+++ b/src/main/java/au/gov/ga/geodesy/bindings/AppConfig.java
@@ -1,10 +1,18 @@
 package au.gov.ga.geodesy.bindings;
  
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+
+import au.gov.ga.geodesy.interfaces.geodesyml.GeodesyMLMarshaller;
+import au.gov.ga.geodesy.interfaces.geodesyml.MarshallingException;
+import au.gov.ga.geodesy.support.marshalling.moxy.GeodesyMLMoxy;
  
 @Configuration
 @ComponentScan(basePackages = "au.gov.ga.geodesy")
 public class AppConfig {
- 
+    @Bean
+    public GeodesyMLMarshaller getGeodesyMLMarshaller() throws MarshallingException {
+        return new GeodesyMLMoxy();
+    }
 }

--- a/src/main/java/au/gov/ga/geodesy/interfaces/geodesyml/GeodesyMLMarshaller.java
+++ b/src/main/java/au/gov/ga/geodesy/interfaces/geodesyml/GeodesyMLMarshaller.java
@@ -9,6 +9,6 @@ import javax.xml.bind.JAXBElement;
 import java.io.Reader;
 
 public interface GeodesyMLMarshaller {
-    void marshal(GeodesyMLType doc, Writer writer) throws MarshallingException;
+    void marshal(JAXBElement<GeodesyMLType> doc, Writer writer) throws MarshallingException;
     JAXBElement<GeodesyMLType> unmarshal(Reader reader) throws MarshallingException;
 }

--- a/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
+++ b/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
@@ -34,6 +34,7 @@ public class GeodesyMLMoxy implements GeodesyMLMarshaller {
             Marshaller marshaller = jaxbContext.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
             marshaller.setProperty(Marshaller.JAXB_ENCODING, "ISO-8859-1");
+            marshaller.setProperty(Marshaller.JAXB_SCHEMA_LOCATION, "urn:xml-gov-au:icsm:egeodesy:0.2");
             return marshaller;
         } catch (JAXBException e) {
             throw new MarshallingException("Failed to create marshaller", e);
@@ -49,7 +50,7 @@ public class GeodesyMLMoxy implements GeodesyMLMarshaller {
         }
     }
 
-    public void marshal(GeodesyMLType site, Writer writer) throws MarshallingException {
+    public void marshal(JAXBElement<GeodesyMLType> site, Writer writer) throws MarshallingException {
         try {
             createMarshaller().marshal(site, writer);
         } catch (JAXBException e) {

--- a/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
+++ b/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
@@ -11,12 +11,11 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
-import org.springframework.stereotype.Component;
 
 import au.gov.ga.geodesy.interfaces.geodesyml.GeodesyMLMarshaller;
 import au.gov.ga.geodesy.interfaces.geodesyml.MarshallingException;
 import au.gov.xml.icsm.geodesyml.v_0_2_2.GeodesyMLType;
-@Component
+
 public class GeodesyMLMoxy implements GeodesyMLMarshaller {
 
     private JAXBContext jaxbContext;

--- a/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
+++ b/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
@@ -11,11 +11,13 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.springframework.stereotype.Component;
 
 import au.gov.ga.geodesy.interfaces.geodesyml.GeodesyMLMarshaller;
 import au.gov.ga.geodesy.interfaces.geodesyml.MarshallingException;
 import au.gov.xml.icsm.geodesyml.v_0_2_2.GeodesyMLType;
 
+@Component
 public class GeodesyMLMoxy implements GeodesyMLMarshaller {
 
     private JAXBContext jaxbContext;

--- a/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
+++ b/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
@@ -11,11 +11,12 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
 import org.eclipse.persistence.jaxb.JAXBContextFactory;
+import org.springframework.stereotype.Component;
 
 import au.gov.ga.geodesy.interfaces.geodesyml.GeodesyMLMarshaller;
 import au.gov.ga.geodesy.interfaces.geodesyml.MarshallingException;
 import au.gov.xml.icsm.geodesyml.v_0_2_2.GeodesyMLType;
-
+@Component
 public class GeodesyMLMoxy implements GeodesyMLMarshaller {
 
     private JAXBContext jaxbContext;

--- a/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-gco.xml
+++ b/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-gco.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<xml-bindings package-name="net.opengis.iso19139.gco.v_20070417" version="2.5" xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/oxm">
+    <xml-schema element-form-default="QUALIFIED">
+        <xml-ns namespace-uri="http://www.isotc211.org/2005/gco" prefix="gco"/>
+     </xml-schema>
+</xml-bindings>

--- a/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-gmd.xml
+++ b/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-gmd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<xml-bindings package-name="net.opengis.iso19139.gmd.v_20070417" version="2.5" xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/oxm">
+    <xml-schema element-form-default="QUALIFIED">
+        <xml-ns namespace-uri="http://www.isotc211.org/2005/gmd" prefix="gmd"/>
+     </xml-schema>
+</xml-bindings>

--- a/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-gml.xml
+++ b/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-gml.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<xml-bindings package-name="net.opengis.gml.v_3_2_1" version="2.5" xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/oxm">
+    <xml-schema element-form-default="QUALIFIED">
+        <xml-ns namespace-uri="http://www.opengis.net/gml/3.2" prefix="gml"/>
+     </xml-schema>
+</xml-bindings>

--- a/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-gmx.xml
+++ b/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-gmx.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<xml-bindings package-name="net.opengis.iso19139.gmx.v_20070417" version="2.5" xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/oxm">
+    <xml-schema element-form-default="QUALIFIED">
+        <xml-ns namespace-uri="http://www.isotc211.org/2005/gmx" prefix="gmx"/>
+     </xml-schema>
+</xml-bindings>

--- a/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-om.xml
+++ b/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml-infra-om.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<xml-bindings package-name="net.opengis.om.v_2_0" version="2.5" xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/oxm">
+    <xml-schema element-form-default="QUALIFIED">
+        <xml-ns namespace-uri="http://www.opengis.net/om/2.0" prefix="om"/>
+     </xml-schema>
+</xml-bindings>

--- a/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml.xml
+++ b/src/main/resources/au/gov/ga/geodesy/support/marshalling/moxy/geodesyml.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<xml-bindings package-name="au.gov.xml.icsm.geodesyml.v_0_2_2" version="2.5" xmlns="http://www.eclipse.org/eclipselink/xsds/persistence/oxm">
+    <xml-schema element-form-default="QUALIFIED">
+        <xml-ns namespace-uri="urn:xml-gov-au:icsm:egeodesy:0.2" prefix="geo"/>
+    </xml-schema>
+</xml-bindings>

--- a/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import au.gov.ga.geodesy.bindings.AppConfig;
+import au.gov.ga.geodesy.interfaces.geodesyml.GeodesyMLMarshaller;
 import au.gov.xml.icsm.geodesyml.v_0_2_2.GeodesyMLType;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -25,7 +26,7 @@ import au.gov.xml.icsm.geodesyml.v_0_2_2.GeodesyMLType;
 public class GeodesyMLMoxyTest {
 
     @Autowired
-    private GeodesyMLMoxy marshaller;
+    private GeodesyMLMarshaller marshaller;
 
 //    public GeodesyMLMoxyTest() throws Exception {
 //        marshaller = new GeodesyMLMoxy();

--- a/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
@@ -28,10 +28,6 @@ public class GeodesyMLMoxyTest {
     @Autowired
     private GeodesyMLMarshaller marshaller;
 
-//    public GeodesyMLMoxyTest() throws Exception {
-//        marshaller = new GeodesyMLMoxy();
-//    }
-
     @Test
     public void unmarshal() throws Exception {
         Reader input = new InputStreamReader(Thread.currentThread()

--- a/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
@@ -2,18 +2,34 @@ package au.gov.ga.geodesy.support.marshalling.moxy;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.util.List;
 
+import javax.xml.bind.JAXBElement;
+
+import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
+import au.gov.ga.geodesy.bindings.AppConfig;
 import au.gov.xml.icsm.geodesyml.v_0_2_2.GeodesyMLType;
 
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(
+    classes = {AppConfig.class},
+    loader  = AnnotationConfigContextLoader.class
+)
 public class GeodesyMLMoxyTest {
 
+    @Autowired
     private GeodesyMLMoxy marshaller;
 
-    public GeodesyMLMoxyTest() throws Exception {
-        marshaller = new GeodesyMLMoxy();
-    }
+//    public GeodesyMLMoxyTest() throws Exception {
+//        marshaller = new GeodesyMLMoxy();
+//    }
 
     @Test
     public void unmarshal() throws Exception {
@@ -22,9 +38,13 @@ public class GeodesyMLMoxyTest {
             .getResourceAsStream("MOBS.xml"));
 
         GeodesyMLType geodesyML = marshaller.unmarshal(input).getValue();
+        List<JAXBElement<?>> els = geodesyML.getNodeOrAbstractPositionOrPositionPairCovariance();
+        Assert.assertNotNull(els);
+        Assert.assertNotEquals(0, els.size());
 
+        System.out.println("geodesyML.getNodeOrAbstractPositionOrPositionPairCovariance elements:");
         geodesyML.getNodeOrAbstractPositionOrPositionPairCovariance().forEach(x -> {
-            System.out.println(x.getName());
+            System.out.println("  "+x.getName());
         });
     }
 }


### PR DESCRIPTION
- Set a default schema when marshalling
- Set default namespaces eg. for gml, gmd, gmx, co, ... or else marshalling gives ns such as 'ns0'
- Return top-level element (previously none being used in XML from marshalling)
