### PR TITLE
Re-introduce marshalling of plain DTOs

### DIFF
--- a/src/main/java/au/gov/ga/geodesy/interfaces/geodesyml/GeodesyMLMarshaller.java
+++ b/src/main/java/au/gov/ga/geodesy/interfaces/geodesyml/GeodesyMLMarshaller.java
@@ -1,7 +1,5 @@
 package au.gov.ga.geodesy.interfaces.geodesyml;
 
-import au.gov.xml.icsm.geodesyml.v_0_2_2.GeodesyMLType;
-
 import java.io.Writer;
 
 import javax.xml.bind.JAXBElement;
@@ -10,5 +8,10 @@ import java.io.Reader;
 
 public interface GeodesyMLMarshaller {
     void marshal(JAXBElement<?> doc, Writer writer) throws MarshallingException;
+    void marshal(Object x, Writer writer) throws MarshallingException;
+
+
+    // TODO: unmarshal to plain DTO instead, why not?
     <T> JAXBElement<T> unmarshal(Reader reader, Class<T> type) throws MarshallingException;
+
 }

--- a/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
+++ b/src/main/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxy.java
@@ -2,6 +2,7 @@ package au.gov.ga.geodesy.support.marshalling.moxy;
 
 import java.io.Reader;
 import java.io.Writer;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -79,6 +80,25 @@ public class GeodesyMLMoxy implements GeodesyMLMarshaller {
             createMarshaller().marshal(site, writer);
         } catch (JAXBException e) {
             throw new MarshallingException("Failed to marshal a site log", e);
+        }
+    }
+
+    public void marshal(Object x, Writer writer) throws MarshallingException {
+        // TODO: how can we restrict x?
+        String typeName = x.getClass().getSimpleName();
+        String factoryName = x.getClass().getPackage().getName() + ".ObjectFactory";
+        String factoryMethodName = "create" + typeName.substring(0, typeName.length() - "Type".length());
+        try {
+            Class<?> factoryClass = Class.forName(factoryName);
+            Object factory = factoryClass.newInstance();
+            Method factoryMethod = factoryClass.getMethod(factoryMethodName, new Class<?>[]{x.getClass()});
+            JAXBElement<?> element = (JAXBElement<?>) factoryMethod.invoke(factory, new Object[]{x});
+            marshal(element, writer);
+        } catch (MarshallingException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
@@ -47,11 +47,21 @@ public class GeodesyMLMoxyTest {
     }
 
     @Test
-    public void marshal() throws Exception {
+    public void marshalJAXBElement() throws Exception {
         Reader input = new InputStreamReader(Thread.currentThread()
             .getContextClassLoader()
             .getResourceAsStream("MOBS.xml"));
 
         marshaller.marshal(marshaller.unmarshal(input, GeodesyMLType.class), new PrintWriter(System.out));
+    }
+
+    @Test
+    public void marshal() throws Exception {
+        Reader input = new InputStreamReader(Thread.currentThread()
+            .getContextClassLoader()
+            .getResourceAsStream("MOBS.xml"));
+
+        GeodesyMLType ml = marshaller.unmarshal(input, GeodesyMLType.class).getValue();
+        marshaller.marshal(ml, new PrintWriter(System.out));
     }
 }


### PR DESCRIPTION
Lookup dynamically the ObjectFactory corresponding to the passed in DTO and construct internally the JAXB wrapper.
