### PR TITLE
Generate gml:id where absent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>net.bramp.objectgraph</groupId>
+            <artifactId>objectgraph</artifactId>
+            <version>1.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
@@ -64,6 +69,18 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.19</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-matchers</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-xml</artifactId>
+            <version>0.17.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <profiles>

--- a/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
+++ b/src/test/java/au/gov/ga/geodesy/support/marshalling/moxy/GeodesyMLMoxyTest.java
@@ -3,22 +3,31 @@ package au.gov.ga.geodesy.support.marshalling.moxy;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.Reader;
+import java.io.StringWriter;
 import java.util.List;
 
 import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.NamespaceContext;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XPathContext;
 
 import au.gov.ga.geodesy.port.adapter.geodesyml.MarshallingException;
 import au.gov.xml.icsm.geodesyml.v_0_4.GeodesyMLType;
 import au.gov.xml.icsm.geodesyml.v_0_4.HumiditySensorType;
+import au.gov.xml.icsm.geodesyml.v_0_4.SiteType;
 
 public class GeodesyMLMoxyTest {
 
-    private GeodesyMLMoxy marshaller;
-
-    public GeodesyMLMoxyTest() throws MarshallingException {
+    private static final NamespaceContext namespaces = new XPathContext()
+        .add("geo", "urn:xml-gov-au:icsm:egeodesy:0.4")
+        .add("gml", "http://www.opengis.net/gml/3.2");
+    
+    private GeodesyMLMoxy marshaller; public GeodesyMLMoxyTest() throws MarshallingException {
         marshaller = new GeodesyMLMoxy();
     }
 
@@ -37,6 +46,21 @@ public class GeodesyMLMoxyTest {
         geodesyML.getElements().forEach(x -> {
             System.out.println("  "+x.getName());
         });
+    }
+
+    @Test
+    public void generateGmlId() throws Exception {
+        Reader input = new InputStreamReader(Thread.currentThread()
+            .getContextClassLoader()
+            .getResourceAsStream("MOBS.xml"));
+
+        GeodesyMLType geodesyML = marshaller.unmarshal(input, GeodesyMLType.class).getValue();
+        SiteType siteLogType = (SiteType) geodesyML.getElements().get(0).getValue();
+        siteLogType.setId(null);
+
+        StringWriter xml = new StringWriter();
+        marshaller.marshal(geodesyML, xml);
+        MatcherAssert.assertThat(xml.toString(), XhtmlMatchers.hasXPath("/geo:GeodesyML/geo:Site[@gml:id]", namespaces)); 
     }
 
     @Test


### PR DESCRIPTION
All AbstractGML element subtypes must have a gml:id attribute.