### PR TITLE
Make all property types in monumentInfo.xsd extend GMLPropertyType

### DIFF
--- a/src/main/resources/geodesyml-v_0_5.xjb
+++ b/src/main/resources/geodesyml-v_0_5.xjb
@@ -84,4 +84,10 @@
             <inheritance:implements>au.gov.ga.geodesy.support.gml.LogItemPropertyType</inheritance:implements>
         </jaxb:bindings>
     </jaxb:bindings>
+
+    <jaxb:bindings schemaLocation="http://xml.gov.au/icsm/geodesyml/0.5/monumentInfo.xsd" node="/xs:schema">
+        <jaxb:bindings multiple="true" node="//xs:complexType[substring(@name, string-length(@name) - string-length('PropertyType') + 1) = 'PropertyType']">
+            <inheritance:implements>au.gov.ga.geodesy.support.gml.GMLPropertyType</inheritance:implements>
+        </jaxb:bindings>
+    </jaxb:bindings>
 </jaxb:bindings>


### PR DESCRIPTION
The four property types in monumentInfo.xsd will extend GMLPropertyType: SiteIdentificationPropertyType, SiteLocationPropertyType, FormInfomationPropertyType MoreInfomationPropertyType.